### PR TITLE
A: fandom.com

### DIFF
--- a/filters/web_annoyances.txt
+++ b/filters/web_annoyances.txt
@@ -380,6 +380,7 @@ f-secure.com###article-sidebar
 fablesofaesop.com###prvcypop_372
 failory.com###magnify-widget-container
 fairygodboss.com##.fixedBottom
+fandom.com##.page__right-rail
 fanucamerica.com###myBtn
 fark.com##.new_to_fark_p
 fark.com##.top_right_container


### PR DESCRIPTION
Remove low-quality content (recently uploaded pictures, list of all avatars currently online on discord,...) from right sidebar, reclaim screen real estate for text and actual content.