### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,5 +1,9 @@
 name: Auto Approve
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   pull_request_target:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/webannoyances/security/code-scanning/1](https://github.com/LanikSJ/webannoyances/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function. Since the workflow is approving pull requests, it needs `pull-requests: write` permission. Additionally, it may need `contents: read` to access repository contents. These permissions will be explicitly set to ensure the workflow operates securely.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
