### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node-update-deps.yml
+++ b/.github/workflows/node-update-deps.yml
@@ -1,4 +1,7 @@
 name: NodeJS Dependencies Update
+permissions:
+  contents: write
+  pull-requests: write
 
 env:
   NODE_VERSION: 20


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/webannoyances/security/code-scanning/3](https://github.com/LanikSJ/webannoyances/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the operations performed in the workflow (e.g., creating branches, committing changes, pushing to the repository, and creating pull requests), the following permissions are necessary:
- `contents: write` for pushing changes to the repository.
- `pull-requests: write` for creating pull requests.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `node-deps-update` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
