### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -12,6 +12,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   # For non-forks, we will maintain a sibling PR
   restyled:


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/webannoyances/security/code-scanning/5](https://github.com/LanikSJ/webannoyances/security/code-scanning/5)

To fix the issue, we need to add an explicit `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. For example:
- `contents: read` for reading repository contents.
- `pull-requests: write` for creating and managing pull requests.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within each job to define specific permissions for that job. In this case, adding the block at the root level is the most efficient approach, as it ensures all jobs inherit the same minimal permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
