### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-license.yml
+++ b/.github/workflows/update-license.yml
@@ -1,4 +1,7 @@
 name: Update License
+permissions:
+  contents: write
+  pull-requests: write
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/webannoyances/security/code-scanning/7](https://github.com/LanikSJ/webannoyances/security/code-scanning/7)

To fix the issue, we will add a `permissions` block at the root of the workflow. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's steps:
- The `contents: write` permission is needed for the `FantasticFiasco/action-update-license-year` action to update the license file and create a pull request.
- The `pull-requests: write` permission is needed for the `gh pr merge` command to merge the pull request.

The `permissions` block will be added after the `name` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
