### PR TITLE
Remove clutter from all fandom.com wikis

### DIFF
--- a/filters/web_annoyances.txt
+++ b/filters/web_annoyances.txt
@@ -371,6 +371,9 @@ fablesofaesop.com###prvcypop_372
 failory.com###magnify-widget-container
 fairygodboss.com##.fixedBottom
 fandom.com##.page__right-rail
+fandom.com##.global-footer
+fandom.com##.main-page-tag-rcs
+fandom.com###mw-data-after-content
 fanucamerica.com###myBtn
 fark.com##.new_to_fark_p
 fark.com##.top_right_container


### PR DESCRIPTION
Removes discord chat, comment threads, and branding, all taking up screen real estate. 