### PR TITLE
feat: update lock-threads workflow with new schedule, trigger, and permissions

### DIFF
--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -7,17 +7,18 @@ on:
     branches-ignore:
       - dependabot/**
   schedule:
-    # Once every month on the 1st at 14:15 UTC
-    - cron: "15 14 1 * *"
+    # Once every month on 2nd at 15:05 UTC
+    - cron: "5 15 2 * *"
   issue_comment:
+  workflow_dispatch:
 
 permissions:
   issues: write
   pull-requests: write
+  discussions: write
 
 concurrency:
   group: lock-threads
-  cancel-in-progress: ${{ github.event_name != 'issue_comment' }}
 
 jobs:
   lock-threads:
@@ -29,6 +30,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           process-only: 'issues, prs'
           issue-inactive-days: 30
-          add-issue-labels: outdated
+          add-issue-labels: 'outdated'
           pr-inactive-days: 30
-          add-pr-labels: outdated
+          add-pr-labels: 'outdated'


### PR DESCRIPTION
- Change monthly schedule from 1st at 14:15 UTC to 2nd at 15:05 UTC
- Add workflow_dispatch trigger for manual execution
- Add discussions write permission for broader access
- Remove concurrency cancel-in-progress setting
- Quote label values for consistency ('outdated')
