### PR TITLE
ci: add FOP CLI installation to dead-domains-check workflow

### DIFF
--- a/.github/workflows/dead-domains-check.yml
+++ b/.github/workflows/dead-domains-check.yml
@@ -44,6 +44,9 @@ jobs:
           install-modules: |
             Path::Tiny
 
+      - name: Install FOP CLI
+        run: npm install -g fop-cli
+
       - name: Install Dependencies
         run: pnpm install
 


### PR DESCRIPTION
- Added a new step to install FOP CLI globally using npm, enabling file operations required by the workflow.

