### PR TITLE
chore: Add FOP CLI config and VSCode templates

### DIFF
--- a/.fopconfig
+++ b/.fopconfig
@@ -1,0 +1,14 @@
+# FOP Configuration File
+# Place in current directory or ~/.fopconfig
+
+# Skip commit prompt
+no-commit = true
+
+# Skip sorting (only tidy and combine rules)
+no-sort = true
+
+# Fix cosmetic rule typos in all files
+fix-typos = true
+
+# Suppress most output (for CI)
+quiet = false

--- a/.gitignore
+++ b/.gitignore
@@ -179,11 +179,6 @@ dist
 .pnp.*
 
 ### VisualStudioCode template
-.vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
 *.code-workspace
 
 # Local History for Visual Studio Code

--- a/.vscode/README.md
+++ b/.vscode/README.md
@@ -1,0 +1,74 @@
+# VS Code Configuration for FOP
+
+Pre-configured VS Code settings for filter list projects.
+
+## Quick Setup
+
+### Option 1: Run setup script
+
+```bash
+cd /path/to/your/filterlist
+bash /path/to/.vscode/setup.sh .
+```
+
+### Option 2: Copy manually
+
+```bash
+cp -r .vscode /path/to/your/filterlist/
+```
+
+## Included Files
+
+| File | Purpose |
+| ------ | --------- |
+| `tasks.json` | FOP tasks (Sort All, Sort File, Fix Typos, etc.) |
+| `settings.json` | Editor settings for filter lists |
+| `extensions.json` | Recommended extensions |
+| `keybindings.example.jsonc` | Keyboard shortcut examples (copy to user settings) |
+| `setup.sh` | Setup script for easy installation |
+
+## Usage
+
+### Run Tasks
+
+- **Windows/Linux:** `Ctrl+Shift+P` → "Tasks: Run Task" → Select FOP task
+- **macOS:** `Cmd+Shift+P` → "Tasks: Run Task" → Select FOP task
+
+Or use `Ctrl+Shift+B` / `Cmd+Shift+B` for the default task (FOP: Sort All).
+
+### Available Tasks
+
+| Task | Description |
+| ------ | ------------- |
+| FOP: Sort All | Sort all files in project |
+| FOP: Sort Current File | Sort currently open file |
+| FOP: Sort and Commit | Sort all + git commit prompt |
+| FOP: Preview Changes (Diff) | Preview changes without modifying |
+| FOP: Fix Typos | Fix typos in all files |
+| FOP: Fix Typos and Commit | Fix typos + git commit prompt |
+
+### Keyboard Shortcuts (Optional)
+
+Copy shortcuts from `keybindings.example.jsonc` to your VS Code user keybindings:
+
+- `Ctrl+K Ctrl+S` → Click the `{}` icon (Open Keyboard Shortcuts JSON)
+- `Ctrl+K Ctrl+S` â Click the `{}` icon (Open Keyboard Shortcuts JSON)
+
+## Recommended Extensions
+
+When you open the project, VS Code will prompt to install:
+
+- **GitLens** - Enhanced Git integration  
+- **Run on Save** - Auto-run FOP on save (optional)
+
+## Customization
+
+Edit `.fopconfig` in your project root for FOP settings:
+
+```ini
+no-commit = true
+fix-typos = true
+quiet = false
+```
+
+See [FOP README](https://github.com/ryanbr/fop-rs/blob/main/README.md) for all configuration options.

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "adguard.adblock",
+    "eamodio.gitlens",
+    "emeraldwalk.RunOnSave"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,17 @@
+{
+  "files.associations": {
+    "*.txt": "adblock"
+  },
+  "editor.formatOnSave": false,
+  "[adblock]": {
+    "editor.formatOnSave": false,
+    "editor.wordWrap": "on",
+    "editor.tabSize": 2
+  },
+  "[plaintext]": {
+    "editor.formatOnSave": false,
+    "editor.wordWrap": "on"
+  },
+  "files.trimTrailingWhitespace": false,
+  "files.insertFinalNewline": true
+}

--- a/.vscode/setup.sh
+++ b/.vscode/setup.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# FOP VS Code Setup Script
+# Copies VS Code configuration to your filter list project
+
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo "FOP VS Code Setup"
+echo "================="
+echo ""
+
+# Get target directory
+TARGET="${1:-.}"
+
+if [ ! -d "$TARGET" ]; then
+    echo -e "${RED}Error: Directory '$TARGET' does not exist${NC}"
+    exit 1
+fi
+
+# Get script directory (where .vscode files are)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Check if we're in the .vscode folder
+if [[ "$SCRIPT_DIR" == *".vscode" ]]; then
+    SOURCE_DIR="$SCRIPT_DIR"
+else
+    SOURCE_DIR="$SCRIPT_DIR/.vscode"
+fi
+
+if [ ! -d "$SOURCE_DIR" ]; then
+    echo -e "${RED}Error: Cannot find .vscode source folder${NC}"
+    exit 1
+fi
+
+TARGET_VSCODE="$TARGET/.vscode"
+
+# Create .vscode folder if needed
+if [ -d "$TARGET_VSCODE" ]; then
+    echo -e "${YELLOW}Warning: .vscode folder already exists in $TARGET${NC}"
+    read -p "Overwrite existing files? (y/N) " -n 1 -r
+    echo ""
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo "Aborted."
+        exit 0
+    fi
+else
+    mkdir -p "$TARGET_VSCODE"
+fi
+
+# Copy files
+echo "Copying VS Code configuration..."
+
+for file in tasks.json settings.json extensions.json; do
+    if [ -f "$SOURCE_DIR/$file" ]; then
+        cp "$SOURCE_DIR/$file" "$TARGET_VSCODE/"
+        echo -e "  ${GREEN}✓${NC} $file"
+    fi
+done
+
+# Copy keybindings example (optional)
+if [ -f "$SOURCE_DIR/keybindings.example.jsonc" ]; then
+    cp "$SOURCE_DIR/keybindings.example.jsonc" "$TARGET_VSCODE/"
+    echo -e "  ${GREEN}✓${NC} keybindings.example.jsonc"
+fi
+
+echo ""
+
+# Create .fopconfig if it doesn't exist
+if [ ! -f "$TARGET/.fopconfig" ]; then
+    read -p "Create .fopconfig with recommended settings? (Y/n) " -n 1 -r
+    echo ""
+    if [[ ! $REPLY =~ ^[Nn]$ ]]; then
+        cat > "$TARGET/.fopconfig" << 'EOF'
+# FOP Configuration
+# See https://github.com/ryanbr/fop-rs for all options
+
+# Skip commit prompt (use VS Code git integration instead)
+no-commit = true
+
+# Typo detection
+fix-typos = false
+
+# Keep formatting preferences
+keep-empty-lines = false
+backup = false
+
+# Quiet output
+quiet = false
+EOF
+        echo -e "${GREEN}✓${NC} Created .fopconfig"
+    fi
+fi
+
+echo ""
+echo -e "${GREEN}Setup complete!${NC}"
+echo ""
+echo "Next steps:"
+echo "  1. Open your project in VS Code"
+echo "  2. Install recommended extensions when prompted"
+echo "  3. Run FOP: Ctrl+Shift+P → 'Tasks: Run Task' → 'FOP: Sort All'"
+echo ""
+echo "Optional: Copy keyboard shortcuts from keybindings.example.jsonc"
+echo "          to your VS Code user keybindings (Ctrl+K Ctrl+S → {})"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,61 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "FOP: Sort All",
+      "type": "shell",
+      "command": "fop",
+      "args": ["--no-commit", "."],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "panel": "shared"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "FOP: Sort Current File",
+      "type": "shell",
+      "command": "fop",
+      "args": ["--check-file=${file}", "--no-commit"],
+      "group": "build",
+      "problemMatcher": []
+    },
+    {
+      "label": "FOP: Sort and Commit",
+      "type": "shell",
+      "command": "fop",
+      "args": ["."],
+      "group": "build",
+      "problemMatcher": []
+    },
+    {
+      "label": "FOP: Preview Changes (Diff)",
+      "type": "shell",
+      "command": "fop",
+      "args": ["--no-commit", "--output-diff=changes.diff", "."],
+      "group": "build",
+      "problemMatcher": []
+    },
+    {
+      "label": "FOP: Fix Typos",
+      "type": "shell",
+      "command": "fop",
+      "args": ["--fix-typos", "--no-commit", "."],
+      "group": "build",
+      "problemMatcher": []
+    },
+    {
+      "label": "FOP: Fix Typos and Commit",
+      "type": "shell",
+      "command": "fop",
+      "args": ["--fix-typos", "."],
+      "group": "build",
+      "problemMatcher": []
+    }
+  ]
+}


### PR DESCRIPTION
- Remove the .vscode/* ignore pattern and exceptions for settings.json, tasks.json, launch.json, and extensions.json to allow tracking of VSCode configuration files.
- Add FOP CLI Config and VSCode settings
