### PR TITLE
ci(github-actions): exclude .vscode directory from Jekyll workflow triggers

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - README.md
       - _config.yml
+      - '!**/.vscode/**'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
- The addition of '!**/.vscode/**' to the workflow paths prevents unnecessary triggering of the Jekyll GitHub Pages build when only VSCode IDE settings are modified, optimizing CI resource usage.
