### PR TITLE
fix(checksum-sort): correct command invocation for FOP CLI in sorting function

### DIFF
--- a/scripts/checksum-sort.sh
+++ b/scripts/checksum-sort.sh
@@ -171,7 +171,7 @@ sort_filter() {
     fi
   elif command -v fop-cli >/dev/null 2>&1; then
     log_info "🔀 Using FOP CLI (fop-cli)"
-    if fozp-cli "$file" >/dev/null 2>&1; then
+    if fop-cli "$file" >/dev/null 2>&1; then
       log_info "✅ FOP CLI sorting completed successfully"
       return
     else


### PR DESCRIPTION
- Updated the command from `fozp-cli` to `fop-cli` in the `sort_filter` function to ensure proper execution of the FOP CLI for sorting filter rules.

This change enhances the reliability of the script when utilizing the FOP CLI for sorting operations.
