### PR TITLE
chore: configure prettier and migrate markdownlint to toml

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,7 +1,0 @@
-{
-    "default": true,
-    "MD013": {
-        "line_length": 120
-    },
-    "MD041": false
-}

--- a/.markdownlint.toml
+++ b/.markdownlint.toml
@@ -1,0 +1,6 @@
+default = true
+
+[MD013]
+line_length = 120
+
+MD041 = false

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,9 @@
+# Ignore GitHub files from prettier formatting
+.github/
+
+# Other common ignores
+node_modules/
+dist/
+build/
+*.log
+.DS_Store

--- a/.prettierrc.toml
+++ b/.prettierrc.toml
@@ -1,0 +1,4 @@
+printWidth = 140
+singleQuote = true
+semi = true
+useTabs = true


### PR DESCRIPTION
Configures Prettier for code formatting and migrates the markdownlint configuration from JSON to TOML format.

- Migrates `.markdownlint.json` to `.markdownlint.toml`
- Adds `.prettierrc.toml` with base formatting rules
- Adds `.prettierignore` to exclude build artifacts and dependencies
