### PR TITLE
chore: remove typo configuration for .txt files

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,3 +1,0 @@
-[type.po]
-extend-glob = ["*.txt"]
-check-file = false


### PR DESCRIPTION
- We're no longer using typos now
